### PR TITLE
Removing next.SequenceKey from debug log since it is always null here

### DIFF
--- a/CoAP.NET/Layers/TransferLayer.cs
+++ b/CoAP.NET/Layers/TransferLayer.cs
@@ -217,7 +217,7 @@ namespace CoAP.Layers
                         {
                             _outgoing.Remove(msg.SequenceKey);
                             if (log.IsDebugEnabled)
-                                log.Debug("TransferLayer - Freed blockwise upload by completion: " + next.SequenceKey);
+                                log.Debug("TransferLayer - Freed blockwise upload by completion");
                             // restore original request with registered handlers
                             ((Response)msg).Request = (Request)transfer.cache;
                         }


### PR DESCRIPTION
Removing next.SequenceKey from debug log since it is always null here.
Leaving it will throw a null exception.
