### PR TITLE
Exposed things necessary to translate HTTP <--> CoAP

### DIFF
--- a/CoAP.Proxy/Http/IHttpRequest.cs
+++ b/CoAP.Proxy/Http/IHttpRequest.cs
@@ -15,7 +15,7 @@ using System.IO;
 
 namespace CoAP.Http
 {
-    interface IHttpRequest
+    public interface IHttpRequest
     {
         String Url { get; }
         String RequestUri { get; }

--- a/CoAP.Proxy/Http/IHttpResponse.cs
+++ b/CoAP.Proxy/Http/IHttpResponse.cs
@@ -14,7 +14,7 @@ using System.IO;
 
 namespace CoAP.Http
 {
-    interface IHttpResponse
+    public interface IHttpResponse
     {
         Stream OutputStream { get; }
         void AppendHeader(String name, String value);

--- a/CoAP.Proxy/HttpTranslator.cs
+++ b/CoAP.Proxy/HttpTranslator.cs
@@ -20,7 +20,7 @@ using CoAP.Util;
 
 namespace CoAP.Proxy
 {
-    static class HttpTranslator
+    public static class HttpTranslator
     {
         private static readonly Dictionary<HttpStatusCode, StatusCode> http2coapCode = new Dictionary<HttpStatusCode, StatusCode>();
         private static readonly Dictionary<StatusCode, HttpStatusCode> coap2httpCode = new Dictionary<StatusCode, HttpStatusCode>();


### PR DESCRIPTION
At the moment to translate between CoAP and HTTP seems to require hosting a HTTP server using CoAP.NET. However in my application I already have a server with HTTP requests coming in, this change allows me to internally translate those requests into CoAP requests and send them on to the appropriate CoAP device, and then translate back to HTTP for the response.

Signed-off-by: Martin Evans martindevans@gmail.com
