### PR TITLE
Removed 2 lines for mono compatibility

### DIFF
--- a/CoAP.NET/Channel/UDPChannel.cs
+++ b/CoAP.NET/Channel/UDPChannel.cs
@@ -295,8 +295,8 @@ namespace CoAP.Channel
             UDPSocket socket = NewUDPSocket(addressFamily, bufferSize);
 
             // do not throw SocketError.ConnectionReset by ignoring ICMP Port Unreachable
-            const Int32 SIO_UDP_CONNRESET = -1744830452;
-            socket.Socket.IOControl(SIO_UDP_CONNRESET, new Byte[] { 0 }, null);
+            //const Int32 SIO_UDP_CONNRESET = -1744830452;
+            //socket.Socket.IOControl(SIO_UDP_CONNRESET, new Byte[] { 0 }, null);
             return socket;
         }
 


### PR DESCRIPTION
Running the CoAP.Example/CoAP.Client on Linux (using mono 4.0.1) crashes with an exception: "Failed Executing Request: The Descriptor Is Not A Socket", this is caused by the lines which I have removed (commented out).

All three example projects now run under Mono :)