### PR TITLE
Fix for set URI-PORT when set URI again and there is no port value

### DIFF
--- a/CoAP.NET/Request.cs
+++ b/CoAP.NET/Request.cs
@@ -116,18 +116,21 @@ namespace CoAP
                         && !host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
                         UriHost = host;
 
-                    if (port >= 0)
-                    {
-                        if (port != CoapConstants.DefaultPort)
-                            UriPort = port;
-                    }
-                    else
+                    if (port < 0)
                     {
                         if (String.IsNullOrEmpty(value.Scheme) ||
                             String.Equals(value.Scheme, CoapConstants.UriScheme))
                             port = CoapConstants.DefaultPort;
                         else if (String.Equals(value.Scheme, CoapConstants.SecureUriScheme))
                             port = CoapConstants.DefaultSecurePort;
+                    }
+
+                    if (UriPort != port)
+                    {
+                        if (port != CoapConstants.DefaultPort)
+                            UriPort = port;
+                        else
+                            UriPort = 0;
                     }
 
                     Destination = new IPEndPoint(Dns.GetHostAddresses(host)[0], port);


### PR DESCRIPTION
It's fix for setting port when previouse some port value was set and after that new URI without port is set.

Example:
```
Request r = new Request(Method.GET, true)
r.URI = new URI("coap://127.0.0.1:12345/res") //here port is set to 12345
r.URI = new URI("coap://127.0.0.1/res") // here port option was not changed and stay 12345
```