### PR TITLE
Implement OSCOAP to get security running

### DIFF
--- a/CoAP.NET/CoAP.NET40.csproj
+++ b/CoAP.NET/CoAP.NET40.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\NET40\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;COAPALL</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;COAPALL;INCLUDE_OSCOAP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -27,24 +27,18 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\NET40\</OutputPath>
-    <DefineConstants>TRACE;COAPALL</DefineConstants>
+    <DefineConstants>TRACE;COAPALL;INCLUDE_OSCOAP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\NET40\CoAP.NET.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>coapnet.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging">
-      <HintPath>..\packages\Common.Logging.3.0.0\lib\net40\Common.Logging.dll</HintPath>
-    </Reference>
-    <Reference Include="Common.Logging.Core">
-      <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net40\Common.Logging.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
@@ -102,6 +96,12 @@
     <Compile Include="Observe\ReregisterEventArgs.cs" />
     <Compile Include="Option.cs" />
     <Compile Include="OptionType.cs" />
+    <Compile Include="OSCOAP\HKDF.cs" />
+    <Compile Include="OSCOAP\OscoapLayer.cs" />
+    <Compile Include="OSCOAP\OscoapOption.cs" />
+    <Compile Include="OSCOAP\SecureBlockwiseLayer.cs" />
+    <Compile Include="OSCOAP\SecurityContext.cs" />
+    <Compile Include="OSCOAP\SecurityContextSet.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Request.cs" />
     <Compile Include="Response.cs" />
@@ -145,6 +145,16 @@
     <None Include="coapnet.snk" />
     <None Include="packages.config" />
     <None Include="README" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Bouncy-Castle\bc-csharp\crypto\BouncyCastle.csproj">
+      <Project>{4c235092-820c-4deb-9074-d356fb797d8b}</Project>
+      <Name>BouncyCastle</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\COSE\COSE-csharp\COSE\COSE.Net40.csproj">
+      <Project>{d02f476f-bc2c-4d01-bede-eb8e79dd050e}</Project>
+      <Name>COSE.Net40</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/CoAP.NET/CoapConfig.cs
+++ b/CoAP.NET/CoapConfig.cs
@@ -62,6 +62,11 @@ namespace CoAP
         private Int32 _channelReceiveBufferSize;
         private Int32 _channelSendBufferSize;
         private Int32 _channelReceivePacketSize = 2048;
+#if INCLUDE_OSCOAP
+        private Int32 _oscoap_maxMessageSize = 1024;
+        private Int32 _oscoap_defaultBlockSize = CoapConstants.DefaultBlockSize;
+        private Int32 _oscoap_blockwiseStatusLifetime = 10 *60 * 1000; // ms
+#endif
 
         /// <summary>
         /// Instantiate.
@@ -399,6 +404,50 @@ namespace CoAP
             }
         }
 
+#if INCLUDE_OSCOAP
+        /// <inheritdoc/>
+        public Int32 OSCOAP_MaxMessageSize
+        {
+            get { return _oscoap_maxMessageSize; }
+            set
+            {
+                if (_oscoap_maxMessageSize != value)
+                {
+                    _oscoap_maxMessageSize = value;
+                    NotifyPropertyChanged("OSCOAP_MaxMessageSize");
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public Int32 OSCOAP_DefaultBlockSize
+        {
+            get { return _oscoap_defaultBlockSize; }
+            set
+            {
+                if (_oscoap_defaultBlockSize != value)
+                {
+                    _oscoap_defaultBlockSize = value;
+                    NotifyPropertyChanged("OSCOAP_DefaultBlockSize");
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public Int32 OSCOAP_BlockwiseStatusLifetime
+        {
+            get { return _oscoap_blockwiseStatusLifetime; }
+            set
+            {
+                if (_oscoap_blockwiseStatusLifetime != value)
+                {
+                    _oscoap_blockwiseStatusLifetime = value;
+                    NotifyPropertyChanged("OSCOAP_BlockwiseStatusLifetime");
+                }
+            }
+        }
+#endif
+
         /// <inheritdoc/>
         public void Load(String configFile)
         {
@@ -433,6 +482,10 @@ namespace CoAP
             ChannelReceiveBufferSize = GetInt32(nvc, "ChannelReceiveBufferSize", "UDP_CONNECTOR_RECEIVE_BUFFER", ChannelReceiveBufferSize);
             ChannelSendBufferSize = GetInt32(nvc, "ChannelSendBufferSize", "UDP_CONNECTOR_SEND_BUFFER", ChannelSendBufferSize);
             ChannelReceivePacketSize = GetInt32(nvc, "ChannelReceivePacketSize", "UDP_CONNECTOR_DATAGRAM_SIZE", ChannelReceivePacketSize);
+#if INCLUDE_OSCOAP
+            OSCOAP_MaxMessageSize = GetInt32(nvc, "OSCOAP_MaxMessageSize", "MAX_MESSAGE_SIZE", OSCOAP_MaxMessageSize);
+            OSCOAP_DefaultBlockSize = GetInt32(nvc, "OSCOAP_DefaultBlockSize", "DEFAULT_BLOCK_SIZE", OSCOAP_DefaultBlockSize);
+#endif
         }
 
         /// <inheritdoc/>
@@ -462,6 +515,10 @@ namespace CoAP
                 w.Write("ChannelReceiveBufferSize="); w.WriteLine(ChannelReceiveBufferSize);
                 w.Write("ChannelSendBufferSize="); w.WriteLine(ChannelSendBufferSize);
                 w.Write("ChannelReceivePacketSize="); w.WriteLine(ChannelReceivePacketSize);
+#if INCLUDE_OSCOAP
+                w.Write("OSCOAP_MaxMessageSize="); w.WriteLine(OSCOAP_MaxMessageSize);
+                w.Write("OSCOAP_DefaultBlockSize="); w.WriteLine(OSCOAP_DefaultBlockSize);
+#endif
             }
         }
 

--- a/CoAP.NET/CoapConfig.cs
+++ b/CoAP.NET/CoapConfig.cs
@@ -66,6 +66,7 @@ namespace CoAP
         private Int32 _oscoap_maxMessageSize = 1024;
         private Int32 _oscoap_defaultBlockSize = CoapConstants.DefaultBlockSize;
         private Int32 _oscoap_blockwiseStatusLifetime = 10 *60 * 1000; // ms
+        private bool _oscoap_ReplayWindow = true;
 #endif
 
         /// <summary>
@@ -446,6 +447,16 @@ namespace CoAP
                 }
             }
         }
+
+        public bool OSCOAP_ReplayWindow {
+            get { return _oscoap_ReplayWindow; }
+            set {
+                if (_oscoap_ReplayWindow != value) {
+                    _oscoap_ReplayWindow = value;
+                    NotifyPropertyChanged("OSCOAP_ReplayWindow");
+                }
+            }
+        }
 #endif
 
         /// <inheritdoc/>
@@ -485,6 +496,7 @@ namespace CoAP
 #if INCLUDE_OSCOAP
             OSCOAP_MaxMessageSize = GetInt32(nvc, "OSCOAP_MaxMessageSize", "MAX_MESSAGE_SIZE", OSCOAP_MaxMessageSize);
             OSCOAP_DefaultBlockSize = GetInt32(nvc, "OSCOAP_DefaultBlockSize", "DEFAULT_BLOCK_SIZE", OSCOAP_DefaultBlockSize);
+            OSCOAP_ReplayWindow = GetBoolean(nvc, "OSCOAP_ReplayWindow", "REPLAY_WINDOW", OSCOAP_ReplayWindow);
 #endif
         }
 
@@ -518,6 +530,7 @@ namespace CoAP
 #if INCLUDE_OSCOAP
                 w.Write("OSCOAP_MaxMessageSize="); w.WriteLine(OSCOAP_MaxMessageSize);
                 w.Write("OSCOAP_DefaultBlockSize="); w.WriteLine(OSCOAP_DefaultBlockSize);
+                w.Write("OSCOAP_ReplayWindow="); w.WriteLine(OSCOAP_ReplayWindow);
 #endif
             }
         }

--- a/CoAP.NET/ICoapConfig.cs
+++ b/CoAP.NET/ICoapConfig.cs
@@ -67,6 +67,8 @@ namespace CoAP
         Int32 OSCOAP_MaxMessageSize { get; }
         Int32 OSCOAP_DefaultBlockSize { get; }
         Int32 OSCOAP_BlockwiseStatusLifetime { get; }
+
+        bool OSCOAP_ReplayWindow { get; }
 #endif
 
         /// <summary>

--- a/CoAP.NET/ICoapConfig.cs
+++ b/CoAP.NET/ICoapConfig.cs
@@ -63,6 +63,12 @@ namespace CoAP
         Int32 ChannelSendBufferSize { get; }
         Int32 ChannelReceivePacketSize { get; }
 
+#if INCLUDE_OSCOAP
+        Int32 OSCOAP_MaxMessageSize { get; }
+        Int32 OSCOAP_DefaultBlockSize { get; }
+        Int32 OSCOAP_BlockwiseStatusLifetime { get; }
+#endif
+
         /// <summary>
         /// Loads configuration from a config properties file.
         /// </summary>

--- a/CoAP.NET/Message.cs
+++ b/CoAP.NET/Message.cs
@@ -1049,6 +1049,18 @@ namespace CoAP
             SetOption(new BlockOption(OptionType.Block2, num, szx, m));
         }
 
+#if INCLUDE_OSCOAP
+        public OSCOAP.OscoapOption Oscoap
+        {
+            get { return GetFirstOption(OptionType.Oscoap) as OSCOAP.OscoapOption; }
+            set
+            {
+                if (value == null) RemoveOptions(OptionType.Oscoap);
+                else SetOption(value);
+            }
+        }
+#endif
+
         private IEnumerable<T> SelectOptions<T>(OptionType optionType, Func<Option, T> func)
         {
             IEnumerable<Option> opts = GetOptions(optionType);

--- a/CoAP.NET/Net/Exchange.cs
+++ b/CoAP.NET/Net/Exchange.cs
@@ -14,7 +14,9 @@ using System.Collections.Concurrent;
 using CoAP.Observe;
 using CoAP.Stack;
 using CoAP.Util;
+#if INCLUDE_OSCOAP
 using CoAP.OSCOAP;
+#endif
 
 namespace CoAP.Net
 {

--- a/CoAP.NET/Net/Exchange.cs
+++ b/CoAP.NET/Net/Exchange.cs
@@ -14,6 +14,7 @@ using System.Collections.Concurrent;
 using CoAP.Observe;
 using CoAP.Stack;
 using CoAP.Util;
+using CoAP.OSCOAP;
 
 namespace CoAP.Net
 {
@@ -43,6 +44,12 @@ namespace CoAP.Net
         private IEndPoint _endpoint;
         private IOutbox _outbox;
         private IMessageDeliverer _deliverer;
+#if INCLUDE_OSCOAP
+        private BlockwiseStatus _oscoap_requestBlockStatus;
+        private BlockwiseStatus _oscoap_responseBlockStatus;
+        private SecurityContext _oscoap_securityContext;
+        private byte[] _oscoap_sequenceNumber;
+#endif
 
         public event EventHandler Completed;
 
@@ -137,6 +144,45 @@ namespace CoAP.Net
             get { return _block1ToAck; }
             set { _block1ToAck = value; }
         }
+
+#if INCLUDE_OSCOAP
+        /// <summary>
+        /// Gets or sets the status of the security blockwise transfer of the request,
+        /// or null in case of a normal transfer,
+        /// </summary>
+        public BlockwiseStatus OSCOAP_RequestBlockStatus
+        {
+            get { return _oscoap_requestBlockStatus; }
+            set { _oscoap_requestBlockStatus = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the status of the security blockwise transfer of the response,
+        /// or null in case of a normal transfer,
+        /// </summary>
+        public BlockwiseStatus OSCOAP_ResponseBlockStatus
+        {
+            get { return _oscoap_responseBlockStatus; }
+            set { _oscoap_responseBlockStatus = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the OSCOAP security context for the exchange
+        /// </summary>
+        public SecurityContext OscoapContext {
+            get { return _oscoap_securityContext; }
+            set { _oscoap_securityContext = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the sequence number used to link requests and responses
+        /// in OSCOAP authentication
+        /// </summary>
+        public byte[] OscoapSequenceNumber {
+            get { return _oscoap_sequenceNumber; }
+            set { _oscoap_sequenceNumber = value; }
+        }
+#endif
 
         /// <summary>
         /// Gets the time when this exchange was created.

--- a/CoAP.NET/Net/Exchange.cs
+++ b/CoAP.NET/Net/Exchange.cs
@@ -385,13 +385,32 @@ namespace CoAP.Net
             private readonly Uri _uri;
             private readonly System.Net.EndPoint _endpoint;
             private readonly Int32 _hash;
+#if INCLUDE_OSCOAP
+            private readonly byte[] _oscoap;
+#endif
 
+#if INCLUDE_OSCOAP
+            public KeyUri(Uri uri, byte[] oscoap, System.Net.EndPoint ep)
+            {
+                _uri = uri;
+                _endpoint = ep;
+                _oscoap = oscoap;
+                _hash = _uri.GetHashCode() * 31 + ep.GetHashCode();
+
+                if (oscoap != null) {
+                    Int32 hash2 = 0;
+                    for (int i = 0; i < oscoap.Length; i++) hash2 = hash2 * 7 + oscoap[i];
+                    _hash += hash2 * 71;
+                }
+            }
+#else
             public KeyUri(Uri uri, System.Net.EndPoint ep)
             {
                 _uri = uri;
                 _endpoint = ep;
                 _hash = _uri.GetHashCode() * 31 + ep.GetHashCode();
             }
+#endif
 
             /// <inheritdoc/>
             public override Int32 GetHashCode()
@@ -405,13 +424,32 @@ namespace CoAP.Net
                 KeyUri other = obj as KeyUri;
                 if (other == null)
                     return false;
+#if INCLUDE_OSCOAP
+                if (Object.Equals(_uri, other._uri) && Object.Equals(_endpoint, other._endpoint)) {
+                    if (_oscoap != null) {
+                        if (other._oscoap == null) return false;
+                        if (_oscoap.Length != other._oscoap.Length) return false;
+                        for (int i = 0; i < _oscoap.Length; i++) if (_oscoap[i] != other._oscoap[i]) return false;
+                        return true;
+                    }
+                    return other._oscoap == null;
+                }
+                return false;
+#else
                 return Object.Equals(_uri, other._uri) && Object.Equals(_endpoint, other._endpoint);
+#endif
             }
 
             /// <inheritdoc/>
             public override String ToString()
             {
+#if INCLUDE_OSCOAP
+                if (_oscoap == null) return "KeyUri[" + _uri + " for " + _endpoint + "]";
+                
+                return "KeyUri[" + _uri + "for " + _endpoint + " encryption is " + BitConverter.ToString(_oscoap) + "]";
+#else
                 return "KeyUri[" + _uri + " for " + _endpoint + "]";
+#endif
             }
         }
     }

--- a/CoAP.NET/Net/Matcher.cs
+++ b/CoAP.NET/Net/Matcher.cs
@@ -131,7 +131,15 @@ namespace CoAP.Net
             if (response.HasOption(OptionType.Block2))
             {
                 Request request = exchange.CurrentRequest;
+#if INCLUDE_OSCOAP
+                byte[] oscoapKey = null;
+                if (request.HasOption(OptionType.Oscoap)) {
+                    oscoapKey = request.Oscoap.RawValue;
+                }
+                Exchange.KeyUri keyUri = new Exchange.KeyUri(request.URI, oscoapKey, response.Destination);
+#else // !INCLUDE_OSCOAP
                 Exchange.KeyUri keyUri = new Exchange.KeyUri(request.URI, response.Destination);
+#endif
                 // Observe notifications only send the first block, hence do not store them as ongoing
                 if (exchange.ResponseBlockStatus != null && !response.HasOption(OptionType.Observe))
                 {
@@ -223,7 +231,15 @@ namespace CoAP.Net
             }
             else
             {
+#if INCLUDE_OSCOAP
+                byte[] oscoapValue = null;
+                if (request.HasOption(OptionType.Oscoap)) {
+                    oscoapValue = request.Oscoap.RawValue;
+                }
+                Exchange.KeyUri keyUri = new Exchange.KeyUri(request.URI, oscoapValue, request.Source);
+#else
                 Exchange.KeyUri keyUri = new Exchange.KeyUri(request.URI, request.Source);
+#endif
 
                 if (log.IsDebugEnabled)
                     log.Debug("Looking up ongoing exchange for " + keyUri);
@@ -438,7 +454,15 @@ namespace CoAP.Net
                 Request request = exchange.CurrentRequest;
                 if (request != null && (request.HasOption(OptionType.Block1) || response.HasOption(OptionType.Block2)))
                 {
+#if INCLUDE_OSCOAP
+                    byte[] oscoapValue = null;
+                    if (request.HasOption(OptionType.Oscoap)) {
+                        oscoapValue = request.Oscoap.RawValue;
+                    }
+                    Exchange.KeyUri uriKey = new Exchange.KeyUri(request.URI, oscoapValue, request.Source);
+#else
                     Exchange.KeyUri uriKey = new Exchange.KeyUri(request.URI, request.Source);
+#endif
                     if (log.IsDebugEnabled)
                         log.Debug("Remote ongoing completed, cleaning up " + uriKey);
                     Exchange exc;

--- a/CoAP.NET/OSCOAP/HKDF.cs
+++ b/CoAP.NET/OSCOAP/HKDF.cs
@@ -1,0 +1,256 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Org.BouncyCastle.Crypto.Macs;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Utilities;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto;
+
+namespace CoAP.OSCOAP
+{
+#if INCLUDE_OSCOAP
+    /**
+    * HMAC-based Extract-and-Expand Key Derivation Function (HKDF) implemented
+    * according to IETF RFC 5869, May 2010 as specified by H. Krawczyk, IBM
+    * Research &amp; P. Eronen, Nokia. It uses a HMac internally to compute de OKM
+    * (output keying material) and is likely to have better security properties
+    * than KDF's based on just a hash function.
+    */
+    public class HkdfBytesGenerator
+        : IDerivationFunction
+    {
+        private HMac hMacHash;
+        private int hashLen;
+
+        private byte[] info;
+        private byte[] currentT;
+
+        private int generatedBytes;
+
+        /**
+         * Creates a HKDFBytesGenerator based on the given hash function.
+         *
+         * @param hash the digest to be used as the source of generatedBytes bytes
+         */
+        public HkdfBytesGenerator(IDigest hash)
+        {
+            this.hMacHash = new HMac(hash);
+            this.hashLen = hash.GetDigestSize();
+        }
+
+        public virtual void Init(IDerivationParameters parameters)
+        {
+            if (!(parameters is HkdfParameters))
+                throw new ArgumentException("HKDF parameters required for HkdfBytesGenerator", "parameters");
+
+            HkdfParameters hkdfParameters = (HkdfParameters)parameters;
+            if (hkdfParameters.SkipExtract) {
+                // use IKM directly as PRK
+                hMacHash.Init(new KeyParameter(hkdfParameters.GetIkm()));
+            }
+            else {
+                hMacHash.Init(Extract(hkdfParameters.GetSalt(), hkdfParameters.GetIkm()));
+            }
+
+            info = hkdfParameters.GetInfo();
+
+            generatedBytes = 0;
+            currentT = new byte[hashLen];
+        }
+
+        /**
+         * Performs the extract part of the key derivation function.
+         *
+         * @param salt the salt to use
+         * @param ikm  the input keying material
+         * @return the PRK as KeyParameter
+         */
+        private KeyParameter Extract(byte[] salt, byte[] ikm)
+        {
+            hMacHash.Init(new KeyParameter(ikm));
+            if (salt == null) {
+                // TODO check if hashLen is indeed same as HMAC size
+                hMacHash.Init(new KeyParameter(new byte[hashLen]));
+            }
+            else {
+                hMacHash.Init(new KeyParameter(salt));
+            }
+
+            hMacHash.BlockUpdate(ikm, 0, ikm.Length);
+
+            byte[] prk = new byte[hashLen];
+            hMacHash.DoFinal(prk, 0);
+            return new KeyParameter(prk);
+        }
+
+        /**
+         * Performs the expand part of the key derivation function, using currentT
+         * as input and output buffer.
+         *
+         * @throws DataLengthException if the total number of bytes generated is larger than the one
+         * specified by RFC 5869 (255 * HashLen)
+         */
+        private void ExpandNext()
+        {
+            int n = generatedBytes / hashLen + 1;
+            if (n >= 256) {
+                throw new DataLengthException(
+                    "HKDF cannot generate more than 255 blocks of HashLen size");
+            }
+            // special case for T(0): T(0) is empty, so no update
+            if (generatedBytes != 0) {
+                hMacHash.BlockUpdate(currentT, 0, hashLen);
+            }
+            hMacHash.BlockUpdate(info, 0, info.Length);
+            hMacHash.Update((byte)n);
+            hMacHash.DoFinal(currentT, 0);
+        }
+
+        public virtual IDigest Digest {
+            get { return hMacHash.GetUnderlyingDigest(); }
+        }
+
+        public virtual int GenerateBytes(byte[] output, int outOff, int len)
+        {
+            if (generatedBytes + len > 255 * hashLen) {
+                throw new DataLengthException(
+                    "HKDF may only be used for 255 * HashLen bytes of output");
+            }
+
+            if (generatedBytes % hashLen == 0) {
+                ExpandNext();
+            }
+
+            // copy what is left in the currentT (1..hash
+            int toGenerate = len;
+            int posInT = generatedBytes % hashLen;
+            int leftInT = hashLen - generatedBytes % hashLen;
+            int toCopy = System.Math.Min(leftInT, toGenerate);
+            Array.Copy(currentT, posInT, output, outOff, toCopy);
+            generatedBytes += toCopy;
+            toGenerate -= toCopy;
+            outOff += toCopy;
+
+            while (toGenerate > 0) {
+                ExpandNext();
+                toCopy = System.Math.Min(hashLen, toGenerate);
+                Array.Copy(currentT, 0, output, outOff, toCopy);
+                generatedBytes += toCopy;
+                toGenerate -= toCopy;
+                outOff += toCopy;
+            }
+
+            return len;
+        }
+    }
+
+    /**
+      * Parameter class for the HkdfBytesGenerator class.
+      */
+    public class HkdfParameters
+        : IDerivationParameters
+    {
+        private readonly byte[] ikm;
+        private readonly bool skipExpand;
+        private readonly byte[] salt;
+        private readonly byte[] info;
+
+        private HkdfParameters(byte[] ikm, bool skip, byte[] salt, byte[] info)
+        {
+            if (ikm == null)
+                throw new ArgumentNullException("ikm");
+
+            this.ikm = Arrays.Clone(ikm);
+            this.skipExpand = skip;
+
+            if (salt == null || salt.Length == 0) {
+                this.salt = null;
+            }
+            else {
+                this.salt = Arrays.Clone(salt);
+            }
+
+            if (info == null) {
+                this.info = new byte[0];
+            }
+            else {
+                this.info = Arrays.Clone(info);
+            }
+        }
+
+        /**
+         * Generates parameters for HKDF, specifying both the optional salt and
+         * optional info. Step 1: Extract won't be skipped.
+         *
+         * @param ikm  the input keying material or seed
+         * @param salt the salt to use, may be null for a salt for hashLen zeros
+         * @param info the info to use, may be null for an info field of zero bytes
+         */
+        public HkdfParameters(byte[] ikm, byte[] salt, byte[] info)
+            : this(ikm, false, salt, info)
+        {
+        }
+
+        /**
+         * Factory method that makes the HKDF skip the extract part of the key
+         * derivation function.
+         *
+         * @param ikm  the input keying material or seed, directly used for step 2:
+         *             Expand
+         * @param info the info to use, may be null for an info field of zero bytes
+         * @return HKDFParameters that makes the implementation skip step 1
+         */
+        public static HkdfParameters SkipExtractParameters(byte[] ikm, byte[] info)
+        {
+            return new HkdfParameters(ikm, true, null, info);
+        }
+
+        public static HkdfParameters DefaultParameters(byte[] ikm)
+        {
+            return new HkdfParameters(ikm, false, null, null);
+        }
+
+        /**
+         * Returns the input keying material or seed.
+         *
+         * @return the keying material
+         */
+        public virtual byte[] GetIkm()
+        {
+            return Arrays.Clone(ikm);
+        }
+
+        /**
+         * Returns if step 1: extract has to be skipped or not
+         *
+         * @return true for skipping, false for no skipping of step 1
+         */
+        public virtual bool SkipExtract {
+            get { return skipExpand; }
+        }
+
+        /**
+         * Returns the salt, or null if the salt should be generated as a byte array
+         * of HashLen zeros.
+         *
+         * @return the salt, or null
+         */
+        public virtual byte[] GetSalt()
+        {
+            return Arrays.Clone(salt);
+        }
+
+        /**
+         * Returns the info field, which may be empty (null is converted to empty).
+         *
+         * @return the info field, never null
+         */
+        public virtual byte[] GetInfo()
+        {
+            return Arrays.Clone(info);
+        }
+    }
+#endif
+}

--- a/CoAP.NET/OSCOAP/OscoapLayer.cs
+++ b/CoAP.NET/OSCOAP/OscoapLayer.cs
@@ -1,0 +1,422 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using CoAP.Log;
+using CoAP.Net;
+using CoAP.Stack;
+using Com.AugustCellars.COSE;
+using PeterO.Cbor;
+
+namespace CoAP.OSCOAP
+{
+#if INCLUDE_OSCOAP
+    public class OscoapLayer : AbstractLayer
+    {
+        static readonly ILogger log = LogManager.GetLogger(typeof(OscoapLayer));
+        static byte[] fixedHeader = new byte[] { 0x40, 0x01, 0xff, 0xff };
+
+
+        /// <summary>
+        /// Constructs a new OSCAP layer.
+        /// </summary>
+        public OscoapLayer(ICoapConfig config)
+        {
+            /*
+            _maxMessageSize = config.MaxMessageSize;
+            _defaultBlockSize = config.DefaultBlockSize;
+            _blockTimeout = config.BlockwiseStatusLifetime;
+            */
+            if (log.IsDebugEnabled)
+                log.Debug("OscoapLayer");  // Print out config if any
+
+            config.PropertyChanged += ConfigChanged;
+        }
+
+        void ConfigChanged(Object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            ICoapConfig config = (ICoapConfig)sender;
+            /*
+            if (String.Equals(e.PropertyName, "MaxMessageSize"))
+                _maxMessageSize = config.MaxMessageSize;
+            else if (String.Equals(e.PropertyName, "DefaultBlockSize"))
+                _defaultBlockSize = config.DefaultBlockSize;
+            else if (String.Equals(e.PropertyName, "BlockwiseStatusLifetime"))
+                _blockTimeout = config.BlockwiseStatusLifetime;
+                */
+        }
+
+        public override void SendRequest(INextLayer nextLayer, Exchange exchange, Request request)
+        {
+            if ((request.OscoapContext != null) || (exchange.OscoapContext != null)) {
+                bool hasPayload = false;
+
+                OSCOAP.SecurityContext ctx = exchange.OscoapContext;
+                if (request.OscoapContext != null) {
+                    ctx = request.OscoapContext;
+                    exchange.OscoapContext = ctx;
+                }
+
+                Codec.IMessageEncoder me = Spec.Default.NewMessageEncoder();
+                Request encryptedRequest = new Request(CoAP.Method.GET);
+
+                if (request.Payload != null) {
+                    hasPayload = true;
+                    encryptedRequest.Payload = request.Payload;
+                }
+
+                MoveRequestHeaders(request, encryptedRequest);
+
+                if (log.IsDebugEnabled) {
+                    log.Debug("New inner response message");
+                    log.Debug(encryptedRequest.ToString());
+                }
+
+                Encrypt0Message enc = new Encrypt0Message(false);
+                byte[] msg = me.Encode(encryptedRequest);
+                int tokenSize = msg[0] & 0xf;
+                byte[] msg2 = new byte[msg.Length - (4 + tokenSize)];
+                Array.Copy(msg, 4 + tokenSize, msg2, 0, msg2.Length);
+                enc.SetContent(msg2);
+
+                // Build the partial URI
+                string partialURI = request.URI.AbsoluteUri; // M00BUG?
+
+                // Build AAD
+                CBORObject aad = CBORObject.NewArray();
+                aad.Add(CBORObject.FromObject(1));
+                aad.Add(CBORObject.FromObject(request.Code));
+                aad.Add(CBORObject.FromObject(ctx.Sender.Algorithm));
+                aad.Add(CBORObject.FromObjectAndTag(partialURI, 32));
+
+                enc.SetExternalData(aad.EncodeToBytes());
+                enc.AddAttribute(HeaderKeys.IV, ctx.Sender.GetIV(ctx.Sender.PartialIV), Attributes.DO_NOT_SEND);
+                enc.AddAttribute(HeaderKeys.PartialIV, CBORObject.FromObject(ctx.Sender.PartialIV), Attributes.PROTECTED);
+                enc.AddAttribute(HeaderKeys.Algorithm, ctx.Sender.Algorithm, Attributes.DO_NOT_SEND);
+                enc.AddAttribute(HeaderKeys.KeyId, CBORObject.FromObject(ctx.Cid), Attributes.PROTECTED);
+
+                enc.Encrypt(ctx.Sender.Key);
+
+                if (hasPayload) {
+                    request.Payload = enc.EncodeToBytes();
+                    request.AddOption(new OSCOAP.OscoapOption());
+                }
+                else {
+                    OSCOAP.OscoapOption o = new OSCOAP.OscoapOption();
+                    o.Set(enc.EncodeToBytes());
+                    request.AddOption(o);
+                }
+            }
+            base.SendRequest(nextLayer, exchange, request);
+        }
+
+        public override void ReceiveRequest(INextLayer nextLayer, Exchange exchange, Request request)
+        {
+            if (request.HasOption(OptionType.Oscoap))
+            {
+                try
+                {
+                    CoAP.Option op = request.GetFirstOption(OptionType.Oscoap);
+                    request.RemoveOptions(OptionType.Oscoap);
+
+                    Encrypt0Message msg;
+                    if (op.RawValue.Length == 0)
+                    {
+                        msg = (Encrypt0Message) Com.AugustCellars.COSE.Message.DecodeFromBytes(request.Payload, Tags.Encrypted);
+                    }
+                    else
+                    {
+                        msg = (Encrypt0Message) Com.AugustCellars.COSE.Message.DecodeFromBytes(op.RawValue, Tags.Encrypted);
+                    }
+
+                    OSCOAP.SecurityContext ctx = exchange.OscoapContext;
+                    if (ctx == null)
+                    {
+                        CBORObject kid = msg.FindAttribute(HeaderKeys.KeyId);
+                        ctx = OSCOAP.SecurityContextSet.AllContexts.FindByKid(kid.GetByteString());
+                        if (ctx == null) return;  // Ignore messages that have no known security context.
+                        exchange.OscoapContext = ctx;  // So we know it on the way back.
+                        request.OscoapContext = ctx;
+                    }
+
+                    String partialURI = request.URI.AbsoluteUri; // M00BUG?
+
+                    //  Build AAD
+                    CBORObject aad = CBORObject.NewArray();
+                    aad.Add(CBORObject.FromObject(1)); // M00BUG
+                    aad.Add(CBORObject.FromObject(request.Code));
+                    aad.Add(CBORObject.FromObject(ctx.Recipient.Algorithm));
+                    aad.Add(CBORObject.FromObjectAndTag(partialURI, 32));
+                    msg.SetExternalData(aad.EncodeToBytes());
+
+                    msg.AddAttribute(HeaderKeys.Algorithm, ctx.Recipient.Algorithm, Attributes.DO_NOT_SEND);
+                    msg.AddAttribute(HeaderKeys.IV, ctx.Recipient.GetIV(msg.FindAttribute(HeaderKeys.PartialIV)), Attributes.DO_NOT_SEND);
+                    exchange.OscoapSequenceNumber = msg.FindAttribute(HeaderKeys.PartialIV).GetByteString();
+
+                    byte[] payload = msg.Decrypt(ctx.Recipient.Key);
+                    byte[] newRequestData = new byte[payload.Length + fixedHeader.Length];
+                    Array.Copy(fixedHeader, newRequestData, fixedHeader.Length);
+                    Array.Copy(payload, 0, newRequestData, fixedHeader.Length, payload.Length);
+
+                    CoAP.Codec.IMessageDecoder me = CoAP.Spec.Default.NewMessageDecoder(newRequestData);
+                    CoAP.Request newRequest = me.DecodeRequest();
+
+                    //  Update headers is a pain
+
+                    RestoreOptions(request, newRequest);
+
+                    request.Payload = newRequest.Payload;
+                }
+                catch (Exception e)
+                {
+                    log.Error("OSCOAP Layer: reject message because " + e.ToString());
+                    exchange.OscoapContext = null;
+                    //  Ignore messages that we cannot decrypt.
+                    return;
+                }
+            }
+
+            base.ReceiveRequest(nextLayer, exchange, request);
+        }
+
+        public override void SendResponse(INextLayer nextLayer, Exchange exchange, Response response)
+        {
+            if (exchange.OscoapContext != null)
+            {
+                OSCOAP.SecurityContext ctx = exchange.OscoapContext;
+
+                Codec.IMessageEncoder me = Spec.Default.NewMessageEncoder();
+                Response encryptedResponse = new Response((CoAP.StatusCode) response.Code);
+
+                bool hasPayload = false;
+                if (response.Payload != null)
+                {
+                    hasPayload = true;
+                    encryptedResponse.Payload = response.Payload;
+                }
+
+                MoveResponseHeaders(response, encryptedResponse);
+
+                if (log.IsDebugEnabled) {
+                    log.Debug("New inner response message");
+                    log.Debug(encryptedResponse.ToString());
+                }
+
+                //  Build AAD
+                CBORObject aad = CBORObject.NewArray();
+                aad.Add(1);
+                aad.Add(response.Code);
+                aad.Add(ctx.Sender.Algorithm);
+                aad.Add(ctx.Cid);
+                aad.Add(ctx.Recipient.Id);
+                aad.Add(exchange.OscoapSequenceNumber);
+
+                Encrypt0Message enc = new Encrypt0Message(false);
+                byte[] msg = me.Encode(encryptedResponse);
+                int tokenSize = msg[0] & 0xf;
+                byte[] msg2 = new byte[msg.Length - (4 + tokenSize)];
+                Array.Copy(msg, 4 + tokenSize, msg2, 0, msg2.Length);
+                enc.SetContent(msg2);
+                enc.SetExternalData(aad.EncodeToBytes());
+
+                enc.AddAttribute(HeaderKeys.IV, ctx.Sender.GetIV(ctx.Sender.PartialIV), Attributes.DO_NOT_SEND);
+                enc.AddAttribute(HeaderKeys.PartialIV, CBORObject.FromObject(ctx.Sender.PartialIV), Attributes.PROTECTED);
+                enc.AddAttribute(HeaderKeys.Algorithm, ctx.Sender.Algorithm, Attributes.DO_NOT_SEND);
+                enc.Encrypt(ctx.Sender.Key);
+
+                if (hasPayload)
+                {
+                    response.Payload = enc.EncodeToBytes();
+                    response.AddOption(new OSCOAP.OscoapOption());
+                }
+                else
+                {
+                    OSCOAP.OscoapOption o = new OSCOAP.OscoapOption();
+                    o.Set(enc.EncodeToBytes());
+                    response.AddOption(o);
+                }
+            }
+
+            base.SendResponse(nextLayer, exchange, response);
+        }
+
+        public override void ReceiveResponse(INextLayer nextLayer, Exchange exchange, Response response)
+        {
+            if (response.HasOption(OptionType.Oscoap))
+            {
+                Encrypt0Message msg;
+                OSCOAP.SecurityContext ctx;
+                Option op = response.GetFirstOption(OptionType.Oscoap);
+
+                if (op.RawValue.Length > 0)
+                {
+                    msg = (Encrypt0Message) Com.AugustCellars.COSE.Message.DecodeFromBytes(op.RawValue, Tags.Encrypted);
+                }
+                else
+                {
+                    msg = (Encrypt0Message) Com.AugustCellars.COSE.Message.DecodeFromBytes(response.Payload, Tags.Encrypted);
+                }
+
+
+                if (exchange.OscoapContext == null)
+                {
+                    return;
+                }
+                else ctx = exchange.OscoapContext;
+
+                msg.AddAttribute(HeaderKeys.Algorithm, ctx.Recipient.Algorithm, Attributes.DO_NOT_SEND);
+                msg.AddAttribute(HeaderKeys.IV, ctx.Recipient.GetIV(msg.FindAttribute(HeaderKeys.PartialIV)), Attributes.DO_NOT_SEND);
+
+                //  build aad
+                CBORObject aad = CBORObject.NewArray();
+                aad.Add(CBORObject.FromObject(1));
+                aad.Add(CBORObject.FromObject(response.Code));
+                aad.Add(ctx.Recipient.Algorithm);
+                aad.Add(ctx.Cid);
+                aad.Add(ctx.Sender.Id);
+                aad.Add(ctx.Sender.PartialIV);
+                msg.SetExternalData(aad.EncodeToBytes());
+
+                byte[] payload = msg.Decrypt(ctx.Recipient.Key);
+                byte[] rgb = new byte[payload.Length + fixedHeader.Length];
+                Array.Copy(fixedHeader, rgb, fixedHeader.Length);
+                Array.Copy(payload,0, rgb, fixedHeader.Length, payload.Length);
+                rgb[1] = 0x45;
+                Codec.IMessageDecoder me = CoAP.Spec.Default.NewMessageDecoder(rgb);
+                Response decryptedReq = me.DecodeResponse();
+
+                response.Payload = decryptedReq.Payload;
+
+                RestoreOptions(response, decryptedReq);
+            }
+            base.ReceiveResponse(nextLayer, exchange, response);
+        }
+
+        void MoveRequestHeaders(Request unprotected, Request encrypted)
+        {
+            List<Option> deleteMe = new List<Option>();
+            int port;
+
+            //  Deal with Proxy-Uri
+            if (unprotected.ProxyUri != null) {
+                if (!unprotected.ProxyUri.IsAbsoluteUri) throw new Exception("Must be an absolute URI");
+                if (unprotected.ProxyUri.Fragment != null) throw new Exception("Fragments not allowed in ProxyUri");
+                switch (unprotected.ProxyUri.Scheme) {
+                    case "coap":
+                    port = 5683;
+                    break;
+
+                    case "coaps":
+                    port = 5684;
+                    break;
+
+                    default:
+                    throw new Exception("Unsupported schema");
+                }
+
+                if (unprotected.ProxyUri.Query != null) {
+                    encrypted.AddUriQuery(unprotected.ProxyUri.Query);
+                    unprotected.ClearUriQuery();
+                }
+
+                if (unprotected.ProxyUri.Host[0] != '[') {
+                    encrypted.UriHost = unprotected.ProxyUri.Host;
+                }
+
+                String strPort = "";
+                if ((unprotected.ProxyUri.Port != 0) && (unprotected.ProxyUri.Port != port)) {
+                    encrypted.UriPort = unprotected.ProxyUri.Port;
+                    strPort = ":" + port.ToString();
+                }
+
+                string p = unprotected.ProxyUri.AbsolutePath;
+                if (p != null) {
+                    encrypted.UriPath = p;
+                }
+                unprotected.URI = new Uri(unprotected.ProxyUri.Scheme + "://" + unprotected.ProxyUri.Host + strPort + "/");
+            }
+
+            List<Option> toDelete = new List<Option>();
+            foreach (Option op in unprotected.GetOptions()) {
+                switch (op.Type) {
+                    case OptionType.UriHost:
+                    case OptionType.UriPort:
+                    case OptionType.ProxyUri:
+                    case OptionType.ProxyScheme:
+                        break;
+
+                    case OptionType.Observe:
+                        encrypted.AddOption(op);
+                        break;
+
+                    default:
+                        encrypted.AddOption(op);
+                        toDelete.Add(op);
+                        break;
+                }
+            }
+
+            foreach (Option op in toDelete) unprotected.RemoveOptions(op.Type);
+            unprotected.URI = null;
+        }
+
+        void MoveResponseHeaders(Response unprotected, Response encrypted)
+        {
+            List<Option> deleteMe = new List<Option>();
+
+            //  Deal with Proxy-Uri
+            if (unprotected.ProxyUri != null) {
+                throw new Exception("Should not see Proxy-Uri on a response.");
+            }
+
+            List<Option> toDelete = new List<Option>();
+            foreach (Option op in unprotected.GetOptions()) {
+                switch (op.Type) {
+                    case OptionType.UriHost:
+                    case OptionType.UriPort:
+                    case OptionType.ProxyUri:
+                    case OptionType.ProxyScheme:
+                        break;
+
+                    case OptionType.Observe:
+                        encrypted.AddOption(op);
+                        break;
+
+                    default:
+                        encrypted.AddOption(op);
+                        toDelete.Add(op);
+                        break;
+                }
+            }
+
+            foreach (Option op in toDelete) unprotected.RemoveOptions(op.Type);
+        }
+
+ void                        RestoreOptions(Message response, Message decryptedReq)
+        {
+            foreach (Option op in response.GetOptions()) {
+                switch (op.Type) {
+                    case OptionType.Block1:
+                    case OptionType.Block2:
+                    case OptionType.Oscoap:
+                        response.RemoveOptions(op.Type);
+                        break;
+
+                    default:
+                        break;
+                }
+            }
+
+            foreach (Option op in decryptedReq.GetOptions()) {
+                switch (op.Type) {
+                    default:
+                        response.AddOption(op);
+                        break;
+                }
+            }
+        }
+
+    }
+#endif
+}

--- a/CoAP.NET/OSCOAP/OscoapOption.cs
+++ b/CoAP.NET/OSCOAP/OscoapOption.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using CoAP;
+
+namespace CoAP.OSCOAP
+{
+#if INCLUDE_OSCOAP
+    public class OscoapOption : Option
+    {
+        public OscoapOption() : base(OptionType.Oscoap)
+        {
+
+        }
+
+        public void Set(byte[] value) { RawValue = value; }
+
+        public override string ToString()
+        {
+            if (this.RawValue == null) return "** InPayload";
+            return String.Format("** Length={0}", this.RawValue.Length);
+        }
+    }
+#endif
+}

--- a/CoAP.NET/OSCOAP/SecureBlockwiseLayer.cs
+++ b/CoAP.NET/OSCOAP/SecureBlockwiseLayer.cs
@@ -1,0 +1,675 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Timers;
+
+using CoAP.Stack;
+using CoAP.Log;
+using CoAP.Net;
+
+namespace CoAP.OSCOAP
+{
+#if INCLUDE_OSCOAP
+    public class SecureBlockwiseLayer : AbstractLayer
+    {
+        static readonly ILogger log = LogManager.GetLogger(typeof(SecureBlockwiseLayer));
+
+        private Int32 _maxMessageSize;
+        private Int32 _defaultBlockSize;
+        private Int32 _blockTimeout;
+
+        public SecureBlockwiseLayer(ICoapConfig config)
+        {
+            _maxMessageSize = config.OSCOAP_MaxMessageSize;
+            _defaultBlockSize = config.OSCOAP_DefaultBlockSize;
+            _blockTimeout = config.OSCOAP_BlockwiseStatusLifetime;
+            if (log.IsDebugEnabled)
+                log.Debug("SecureBlockwiseLayer uses MaxMessageSize: " + _maxMessageSize + " and DefaultBlockSize:" + _defaultBlockSize);
+
+            config.PropertyChanged += ConfigChanged;
+
+        }
+        void ConfigChanged(Object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            ICoapConfig config = (ICoapConfig)sender;
+            if (String.Equals(e.PropertyName, "OSCOAP_MaxMessageSize"))
+                _maxMessageSize = config.OSCOAP_MaxMessageSize;
+            else if (String.Equals(e.PropertyName, "OSCOAP_DefaultBlockSize"))
+                _defaultBlockSize = config.OSCOAP_DefaultBlockSize;
+            else if (String.Equals(e.PropertyName, "OSCOAP_BlockwiseStatusLifetime"))
+                _blockTimeout = config.OSCOAP_BlockwiseStatusLifetime;
+        }
+
+        /// <inheritdoc/>
+        public override void SendRequest(INextLayer nextLayer, Exchange exchange, Request request)
+        {
+            if ((request.Oscoap == null) && (exchange.OscoapContext == null))
+            {
+                base.SendRequest(nextLayer, exchange, request);
+            }
+            else if (request.HasOption(OptionType.Block2) && request.Block2.NUM > 0)
+            {
+                // This is the case if the user has explicitly added a block option
+                // for random access.
+                // Note: We do not regard it as random access when the block num is
+                // 0. This is because the user might just want to do early block
+                // size negotiation but actually wants to receive all blocks.
+                if (log.IsDebugEnabled)
+                    log.Debug("Request carries explicit defined block2 option: create random access blockwise status");
+                BlockwiseStatus status = new BlockwiseStatus(request.ContentFormat);
+                BlockOption block2 = request.Block2;
+                status.CurrentSZX = block2.SZX;
+                status.CurrentNUM = block2.NUM;
+                status.IsRandomAccess = true;
+                exchange.OSCOAP_ResponseBlockStatus = status;
+                base.SendRequest(nextLayer, exchange, request);
+            }
+            else if (RequiresBlockwise(request))
+            {
+                // This must be a large POST or PUT request
+                if (log.IsDebugEnabled)
+                    log.Debug("Request payload " + request.PayloadSize + "/" + _maxMessageSize + " requires Blockwise.");
+                BlockwiseStatus status = FindRequestBlockStatus(exchange, request);
+                Request block = GetNextRequestBlock(request, status);
+                exchange.OSCOAP_RequestBlockStatus = status;
+                exchange.CurrentRequest = block;
+                base.SendRequest(nextLayer, exchange, block);
+            }
+            else
+            {
+                exchange.CurrentRequest = request;
+                base.SendRequest(nextLayer, exchange, request);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void ReceiveRequest(INextLayer nextLayer, Exchange exchange, Request request)
+        {
+            if ((request.Oscoap == null) && (exchange.OscoapContext == null))
+            {
+                base.ReceiveRequest(nextLayer, exchange, request);
+            }
+            else if (request.HasOption(OptionType.Block1))
+            {
+                // This must be a large POST or PUT request
+                BlockOption block1 = request.Block1;
+                if (log.IsDebugEnabled)
+                    log.Debug("Request contains block1 option " + block1);
+
+                BlockwiseStatus status = FindRequestBlockStatus(exchange, request);
+                if (block1.NUM == 0 && status.CurrentNUM > 0)
+                {
+                    // reset the blockwise transfer
+                    if (log.IsDebugEnabled)
+                        log.Debug("Block1 num is 0, the client has restarted the blockwise transfer. Reset status.");
+                    status = new BlockwiseStatus(request.ContentType);
+                    exchange.OSCOAP_RequestBlockStatus = status;
+                }
+
+                if (block1.NUM == status.CurrentNUM)
+                {
+                    if (request.ContentType == status.ContentFormat)
+                    {
+                        status.AddBlock(request.Payload);
+                    }
+                    else
+                    {
+                        Response error = Response.CreateResponse(request, StatusCode.RequestEntityIncomplete);
+                        error.AddOption(new BlockOption(OptionType.Block1, block1.NUM, block1.SZX, block1.M));
+                        error.SetPayload("Changed Content-Format");
+
+                        exchange.CurrentResponse = error;
+                        base.SendResponse(nextLayer, exchange, error);
+                        return;
+                    }
+
+                    status.CurrentNUM = status.CurrentNUM + 1;
+                    if (block1.M)
+                    {
+                        if (log.IsDebugEnabled)
+                            log.Debug("There are more blocks to come. Acknowledge this block.");
+
+                        Response piggybacked = Response.CreateResponse(request, StatusCode.Continue);
+                        piggybacked.AddOption(new BlockOption(OptionType.Block1, block1.NUM, block1.SZX, true));
+                        piggybacked.Last = false;
+
+                        exchange.CurrentResponse = piggybacked;
+                        base.SendResponse(nextLayer, exchange, piggybacked);
+
+                        // do not assemble and deliver the request yet
+                    }
+                    else
+                    {
+                        if (log.IsDebugEnabled)
+                            log.Debug("This was the last block. Deliver request");
+
+                        // Remember block to acknowledge. TODO: We might make this a boolean flag in status.
+                        exchange.Block1ToAck = block1;
+
+                        // Block2 early negotiation
+                        EarlyBlock2Negotiation(exchange, request);
+
+                        // Assemble and deliver
+                        Request assembled = new Request(request.Method);
+                        AssembleMessage(status, assembled, request);
+
+                        exchange.Request = assembled;
+                        base.ReceiveRequest(nextLayer, exchange, assembled);
+                    }
+                }
+                else
+                {
+                    // ERROR, wrong number, Incomplete
+                    if (log.IsWarnEnabled)
+                        log.Warn("Wrong block number. Expected " + status.CurrentNUM + " but received " + block1.NUM + ". Respond with 4.08 (Request Entity Incomplete).");
+                    Response error = Response.CreateResponse(request, StatusCode.RequestEntityIncomplete);
+                    error.AddOption(new BlockOption(OptionType.Block1, block1.NUM, block1.SZX, block1.M));
+                    error.SetPayload("Wrong block number");
+                    exchange.CurrentResponse = error;
+                    base.SendResponse(nextLayer, exchange, error);
+                }
+            }
+            else if (exchange.Response != null && request.HasOption(OptionType.Block2))
+            {
+                // The response has already been generated and the client just wants
+                // the next block of it
+                BlockOption block2 = request.Block2;
+                Response response = exchange.Response;
+                BlockwiseStatus status = FindResponseBlockStatus(exchange, response);
+                status.CurrentNUM = block2.NUM;
+                status.CurrentSZX = block2.SZX;
+
+                Response block = GetNextResponseBlock(response, status);
+                block.Token = request.Token;
+                block.RemoveOptions(OptionType.Observe);
+
+                if (status.Complete)
+                {
+                    // clean up blockwise status
+                    if (log.IsDebugEnabled)
+                        log.Debug("Ongoing is complete " + status);
+                    exchange.OSCOAP_ResponseBlockStatus = null;
+                    ClearBlockCleanup(exchange);
+                }
+                else
+                {
+                    if (log.IsDebugEnabled)
+                        log.Debug("Ongoing is continuing " + status);
+                }
+
+                exchange.CurrentResponse = block;
+                base.SendResponse(nextLayer, exchange, block);
+
+            }
+            else
+            {
+                EarlyBlock2Negotiation(exchange, request);
+
+                exchange.Request = request;
+                base.ReceiveRequest(nextLayer, exchange, request);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void SendResponse(INextLayer nextLayer, Exchange exchange, Response response)
+        {
+            if ((exchange.OscoapContext == null) && (response.Oscoap == null))
+            {
+                base.SendResponse(nextLayer, exchange, response);
+                return;
+            }
+
+            BlockOption block1 = exchange.Block1ToAck;
+            if (block1 != null)
+                exchange.Block1ToAck = null;
+
+            if (RequiresBlockwise(exchange, response))
+            {
+                if (log.IsDebugEnabled)
+                    log.Debug("Response payload " + response.PayloadSize + "/" + _maxMessageSize + " requires Blockwise");
+
+                BlockwiseStatus status = FindResponseBlockStatus(exchange, response);
+
+                Response block = GetNextResponseBlock(response, status);
+
+                if (block1 != null) // in case we still have to ack the last block1
+                    block.SetOption(block1);
+                if (block.Token == null)
+                    block.Token = exchange.Request.Token;
+
+                if (status.Complete)
+                {
+                    // clean up blockwise status
+                    if (log.IsDebugEnabled)
+                        log.Debug("Ongoing finished on first block " + status);
+                    exchange.OSCOAP_ResponseBlockStatus = null;
+                    ClearBlockCleanup(exchange);
+                }
+                else
+                {
+                    if (log.IsDebugEnabled)
+                        log.Debug("Ongoing started " + status);
+                }
+
+                exchange.CurrentResponse = block;
+                base.SendResponse(nextLayer, exchange, block);
+            }
+            else
+            {
+                if (block1 != null)
+                    response.SetOption(block1);
+                exchange.CurrentResponse = response;
+                // Block1 transfer completed
+                ClearBlockCleanup(exchange);
+                base.SendResponse(nextLayer, exchange, response);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void ReceiveResponse(INextLayer nextLayer, Exchange exchange, Response response)
+        {
+            if ((exchange.OscoapContext == null) && (response.Oscoap == null))
+            {
+                base.ReceiveResponse(nextLayer, exchange, response);
+                return;
+            }
+
+            // do not continue fetching blocks if canceled
+            if (exchange.Request.IsCancelled)
+            {
+                // reject (in particular for Block+Observe)
+                if (response.Type != MessageType.ACK)
+                {
+                    if (log.IsDebugEnabled)
+                        log.Debug("Rejecting blockwise transfer for canceled Exchange");
+                    EmptyMessage rst = EmptyMessage.NewRST(response);
+                    SendEmptyMessage(nextLayer, exchange, rst);
+                    // Matcher sets exchange as complete when RST is sent
+                }
+                return;
+            }
+
+            if (!response.HasOption(OptionType.Block1) && !response.HasOption(OptionType.Block2))
+            {
+                // There is no block1 or block2 option, therefore it is a normal response
+                exchange.Response = response;
+                base.ReceiveResponse(nextLayer, exchange, response);
+                return;
+            }
+
+            BlockOption block1 = response.Block1;
+            if (block1 != null)
+            {
+                // TODO: What if request has not been sent blockwise (server error)
+                if (log.IsDebugEnabled)
+                    log.Debug("Response acknowledges block " + block1);
+
+                BlockwiseStatus status = exchange.OSCOAP_RequestBlockStatus;
+                if (!status.Complete)
+                {
+                    // TODO: the response code should be CONTINUE. Otherwise deliver
+                    // Send next block
+                    Int32 currentSize = 1 << (4 + status.CurrentSZX);
+                    Int32 nextNum = status.CurrentNUM + currentSize / block1.Size;
+                    if (log.IsDebugEnabled)
+                        log.Debug("Send next block num = " + nextNum);
+                    status.CurrentNUM = nextNum;
+                    status.CurrentSZX = block1.SZX;
+                    Request nextBlock = GetNextRequestBlock(exchange.Request, status);
+                    if (nextBlock.Token == null)
+                        nextBlock.Token = response.Token; // reuse same token
+                    exchange.CurrentRequest = nextBlock;
+                    base.SendRequest(nextLayer, exchange, nextBlock);
+                    // do not deliver response
+                }
+                else if (!response.HasOption(OptionType.Block2))
+                {
+                    // All request block have been acknowledged and we receive a piggy-backed
+                    // response that needs no blockwise transfer. Thus, deliver it.
+                    base.ReceiveResponse(nextLayer, exchange, response);
+                }
+                else
+                {
+                    if (log.IsDebugEnabled)
+                        log.Debug("Response has Block2 option and is therefore sent blockwise");
+                }
+            }
+
+            BlockOption block2 = response.Block2;
+            if (block2 != null)
+            {
+                BlockwiseStatus status = FindResponseBlockStatus(exchange, response);
+
+                if (block2.NUM == status.CurrentNUM)
+                {
+                    // We got the block we expected :-)
+                    status.AddBlock(response.Payload);
+                    Int32? obs = response.Observe;
+                    if (obs.HasValue)
+                        status.Observe = obs.Value;
+
+                    // notify blocking progress
+                    exchange.Request.FireResponding(response);
+
+                    if (status.IsRandomAccess)
+                    {
+                        // The client has requested this specifc block and we deliver it
+                        exchange.Response = response;
+                        base.ReceiveResponse(nextLayer, exchange, response);
+                    }
+                    else if (block2.M)
+                    {
+                        if (log.IsDebugEnabled)
+                            log.Debug("Request the next response block");
+
+                        Request request = exchange.Request;
+                        Int32 num = block2.NUM + 1;
+                        Int32 szx = block2.SZX;
+                        Boolean m = false;
+
+                        Request block = new Request(request.Method);
+                        // NON could make sense over SMS or similar transports
+                        block.Type = request.Type;
+                        block.Destination = request.Destination;
+                        block.SetOptions(request.GetOptions());
+                        block.SetOption(new BlockOption(OptionType.Block2, num, szx, m));
+                        // we use the same token to ease traceability (GET without Observe no longer cancels relations)
+                        block.Token = response.Token;
+                        // make sure not to use Observe for block retrieval
+                        block.RemoveOptions(OptionType.Observe);
+
+                        status.CurrentNUM = num;
+
+                        exchange.CurrentRequest = block;
+                        base.SendRequest(nextLayer, exchange, block);
+                    }
+                    else
+                    {
+                        if (log.IsDebugEnabled)
+                            log.Debug("We have received all " + status.BlockCount + " blocks of the response. Assemble and deliver.");
+                        Response assembled = new Response(response.StatusCode);
+                        AssembleMessage(status, assembled, response);
+                        assembled.Type = response.Type;
+
+                        // set overall transfer RTT
+                        assembled.RTT = (DateTime.Now - exchange.Timestamp).TotalMilliseconds;
+
+                        // Check if this response is a notification
+                        Int32 observe = status.Observe;
+                        if (observe != BlockwiseStatus.NoObserve)
+                        {
+                            assembled.AddOption(Option.Create(OptionType.Observe, observe));
+                            // This is necessary for notifications that are sent blockwise:
+                            // Reset block number AND container with all blocks
+                            exchange.OSCOAP_ResponseBlockStatus = null;
+                        }
+
+                        if (log.IsDebugEnabled)
+                            log.Debug("Assembled response: " + assembled);
+                        exchange.Response = assembled;
+                        base.ReceiveResponse(nextLayer, exchange, assembled);
+                    }
+
+                }
+                else
+                {
+                    // ERROR, wrong block number (server error)
+                    // TODO: This scenario is not specified in the draft.
+                    // Currently, we reject it and cancel the request.
+                    if (log.IsWarnEnabled)
+                        log.Warn("Wrong block number. Expected " + status.CurrentNUM + " but received " + block2.NUM + ". Reject response; exchange has failed.");
+                    if (response.Type == MessageType.CON)
+                    {
+                        EmptyMessage rst = EmptyMessage.NewRST(response);
+                        base.SendEmptyMessage(nextLayer, exchange, rst);
+                    }
+                    exchange.Request.IsCancelled = true;
+                }
+            }
+        }
+
+        private void EarlyBlock2Negotiation(Exchange exchange, Request request)
+        {
+            // Call this method when a request has completely arrived (might have
+            // been sent in one piece without blockwise).
+            if (request.HasOption(OptionType.Block2))
+            {
+                BlockOption block2 = request.Block2;
+                BlockwiseStatus status2 = new BlockwiseStatus(request.ContentType, block2.NUM, block2.SZX);
+                if (log.IsDebugEnabled)
+                    log.Debug("Request with early block negotiation " + block2 + ". Create and set new Block2 status: " + status2);
+                exchange.OSCOAP_ResponseBlockStatus = status2;
+            }
+        }
+
+        /// <summary>
+        /// Notice:
+        /// This method is used by SendRequest and ReceiveRequest.
+        /// Be careful, making changes to the status in here.
+        /// </summary>
+        private BlockwiseStatus FindRequestBlockStatus(Exchange exchange, Request request)
+        {
+            BlockwiseStatus status = exchange.OSCOAP_RequestBlockStatus;
+            if (status == null)
+            {
+                status = new BlockwiseStatus(request.ContentType);
+                status.CurrentSZX = BlockOption.EncodeSZX(_defaultBlockSize);
+                exchange.OSCOAP_RequestBlockStatus = status;
+                if (log.IsDebugEnabled)
+                    log.Debug("There is no assembler status yet. Create and set new Block1 status: " + status);
+            }
+            else
+            {
+                if (log.IsDebugEnabled)
+                    log.Debug("Current Block1 status: " + status);
+            }
+            // sets a timeout to complete exchange
+            PrepareBlockCleanup(exchange);
+            return status;
+        }
+
+        /// <summary>
+        /// Notice:
+        /// This method is used by SendResponse and ReceiveResponse.
+        /// Be careful, making changes to the status in here.
+        /// </summary>
+        private BlockwiseStatus FindResponseBlockStatus(Exchange exchange, Response response)
+        {
+            BlockwiseStatus status = exchange.OSCOAP_ResponseBlockStatus;
+            if (status == null)
+            {
+                status = new BlockwiseStatus(response.ContentType);
+                status.CurrentSZX = BlockOption.EncodeSZX(_defaultBlockSize);
+                exchange.OSCOAP_ResponseBlockStatus = status;
+                if (log.IsDebugEnabled)
+                    log.Debug("There is no blockwise status yet. Create and set new Block2 status: " + status);
+            }
+            else
+            {
+                if (log.IsDebugEnabled)
+                    log.Debug("Current Block2 status: " + status);
+            }
+            // sets a timeout to complete exchange
+            PrepareBlockCleanup(exchange);
+            return status;
+        }
+
+        private Request GetNextRequestBlock(Request request, BlockwiseStatus status)
+        {
+            Int32 num = status.CurrentNUM;
+            Int32 szx = status.CurrentSZX;
+            Request block = new Request(request.Method);
+            block.SetOptions(request.GetOptions());
+            block.Destination = request.Destination;
+            block.Token = request.Token;
+            block.Type = MessageType.CON;
+
+            Int32 currentSize = 1 << (4 + szx);
+            Int32 from = num * currentSize;
+            Int32 to = Math.Min((num + 1) * currentSize, request.PayloadSize);
+            Int32 length = to - from;
+            Byte[] blockPayload = new Byte[length];
+            Array.Copy(request.Payload, from, blockPayload, 0, length);
+            block.Payload = blockPayload;
+
+            Boolean m = to < request.PayloadSize;
+            block.AddOption(new BlockOption(OptionType.Block1, num, szx, m));
+
+            status.Complete = !m;
+            return block;
+        }
+
+        private Response GetNextResponseBlock(Response response, BlockwiseStatus status)
+        {
+            Response block;
+            Int32 szx = status.CurrentSZX;
+            Int32 num = status.CurrentNUM;
+
+            if (response.HasOption(OptionType.Observe))
+            {
+                // a blockwise notification transmits the first block only
+                block = response;
+            }
+            else
+            {
+                block = new Response(response.StatusCode);
+                block.Destination = response.Destination;
+                block.Token = response.Token;
+                block.SetOptions(response.GetOptions());
+                block.TimedOut += (o, e) => response.IsTimedOut = true;
+            }
+
+            Int32 payloadSize = response.PayloadSize;
+            Int32 currentSize = 1 << (4 + szx);
+            Int32 from = num * currentSize;
+            if (payloadSize > 0 && payloadSize > from)
+            {
+                Int32 to = Math.Min((num + 1) * currentSize, response.PayloadSize);
+                Int32 length = to - from;
+                Byte[] blockPayload = new Byte[length];
+                Boolean m = to < response.PayloadSize;
+                block.SetBlock2(szx, m, num);
+
+                // crop payload -- do after calculation of m in case block==response
+                Array.Copy(response.Payload, from, blockPayload, 0, length);
+                block.Payload = blockPayload;
+
+                // do not complete notifications
+                block.Last = !m && !response.HasOption(OptionType.Observe);
+
+                status.Complete = !m;
+            }
+            else
+            {
+                block.AddOption(new BlockOption(OptionType.Block2, num, szx, false));
+                block.Last = true;
+                status.Complete = true;
+            }
+
+            return block;
+        }
+
+        private void AssembleMessage(BlockwiseStatus status, Message message, Message last)
+        {
+            // The assembled request will contain the options of the last block
+            message.ID = last.ID;
+            message.Source = last.Source;
+            message.Token = last.Token;
+            message.Type = last.Type;
+            message.SetOptions(last.GetOptions());
+
+            Int32 length = 0;
+            foreach (Byte[] block in status.Blocks)
+                length += block.Length;
+
+            Byte[] payload = new Byte[length];
+            Int32 offset = 0;
+            foreach (Byte[] block in status.Blocks)
+            {
+                Array.Copy(block, 0, payload, offset, block.Length);
+                offset += block.Length;
+            }
+
+            message.Payload = payload;
+        }
+
+        private Boolean RequiresBlockwise(Request request)
+        {
+            if (request.Method == Method.PUT || request.Method == Method.POST)
+                return request.PayloadSize > _maxMessageSize;
+            else
+                return false;
+        }
+
+        private Boolean RequiresBlockwise(Exchange exchange, Response response)
+        {
+            return response.PayloadSize > _maxMessageSize
+                    || exchange.OSCOAP_ResponseBlockStatus != null;
+        }
+
+        /// <summary>
+        /// Schedules a clean-up task.
+        /// Use the <see cref="ICoapConfig.BlockwiseStatusLifetime"/> to set the timeout.
+        /// </summary>
+        protected void PrepareBlockCleanup(Exchange exchange)
+        {
+            Timer timer = new Timer();
+            timer.AutoReset = false;
+            timer.Interval = _blockTimeout;
+            timer.Elapsed += (o, e) => BlockwiseTimeout(exchange);
+
+            Timer old = exchange.Set("BlockCleanupTimer", timer) as Timer;
+            if (old != null)
+            {
+                try
+                {
+                    old.Stop();
+                    old.Dispose();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // ignore
+                }
+            }
+
+            timer.Start();
+        }
+
+        /// <summary>
+        /// Clears the clean-up task.
+        /// </summary>
+        protected void ClearBlockCleanup(Exchange exchange)
+        {
+            Timer timer = exchange.Remove("BlockCleanupTimer") as Timer;
+            if (timer != null)
+            {
+                try
+                {
+                    timer.Stop();
+                    timer.Dispose();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // ignore
+                }
+            }
+        }
+
+        private void BlockwiseTimeout(Exchange exchange)
+        {
+            if (exchange.Request == null)
+            {
+                if (log.IsInfoEnabled)
+                    log.Info("Block1 transfer timed out: " + exchange.CurrentRequest);
+            }
+            else
+            {
+                if (log.IsInfoEnabled)
+                    log.Info("Block2 transfer timed out: " + exchange.Request);
+            }
+            exchange.Complete = true;
+        }
+    }
+#endif
+}

--- a/CoAP.NET/OSCOAP/SecurityContext.cs
+++ b/CoAP.NET/OSCOAP/SecurityContext.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using PeterO.Cbor;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Macs;
+using Org.BouncyCastle.Crypto.Parameters;
+using Com.AugustCellars.COSE;
+
+namespace CoAP.OSCOAP
+{
+#if INCLUDE_OSCOAP
+    public class SecurityContext
+    {
+        public class replayWindow
+        {
+            BitArray _hits;
+            int _baseValue;
+
+            public replayWindow(int baseValue, int arraySize)
+            {
+                _baseValue = baseValue;
+                _hits = new BitArray(arraySize);
+            }
+        }
+
+        public class EntityContext
+        {
+            CBORObject _algorithm;
+            byte[] _baseIV;
+            byte[] _key;
+            byte[] _id;
+            int _sequenceNumber;
+            replayWindow _replay;
+
+            public CBORObject Algorithm
+            {
+                get { return _algorithm; }
+                set { _algorithm = value; }
+            }
+            public byte[] BaseIV { get { return _baseIV; } set { _baseIV = value; } }
+            public byte[] Id { get { return _id; } set { _id = value; } }
+            public byte[] Key { get { return _key; } set { _key = value; } }
+            public int SequenceNumber { get { return _sequenceNumber; } set { _sequenceNumber = value; } }
+            public byte[] PartialIV
+            {
+                get
+                {
+                    byte[] part = BitConverter.GetBytes(_sequenceNumber);
+                    if (BitConverter.IsLittleEndian) Array.Reverse(part);
+                    int i;
+                    for (i = 0; i < part.Length - 1; i++) if (part[i] != 0) break;
+                    Array.Copy(part, i, part, 0, part.Length - i);
+                    Array.Resize(ref part, part.Length - i);
+
+                    return part;
+                }
+            }
+
+            public CBORObject GetIV(CBORObject partialIV)
+            {
+                return GetIV(partialIV.GetByteString());
+            }
+            public CBORObject GetIV(byte[] partialIV)
+            {
+                byte[] IV = (byte[])_baseIV.Clone();
+                int offset = IV.Length - partialIV.Length;
+
+                for (int i = 0; i < partialIV.Length; i++) IV[i + offset] ^= partialIV[i];
+
+                return CBORObject.FromObject(IV);
+            }
+            public replayWindow ReplayWindow { get { return _replay; } set { _replay = value; } }
+            public void IncrementSequenceNumber() { _sequenceNumber += 1; }
+        }
+
+        EntityContext _sender = new EntityContext();
+        public EntityContext Sender { get { return _sender; } }
+
+        EntityContext _recipient = new EntityContext();
+        public EntityContext Recipient { get { return _recipient; } }
+
+        byte[] _Cid;
+        public byte[] Cid { get { return _Cid; } set { _Cid = value; } }
+
+
+        public static SecurityContext DeriveContext(byte[] Cid, byte[] MasterSecret, byte[] SenderId, byte[] RecipientId, CBORObject AEADAlg = null)
+        {
+            SecurityContext ctx = new SecurityContext();
+            ctx.Cid = Cid;
+            if (AEADAlg == null) ctx.Sender.Algorithm = AlgorithmValues.AES_CCM_64_64_128;
+            else ctx.Sender.Algorithm = AEADAlg;
+            if (SenderId == null) throw new ArgumentNullException("SenderId");
+            ctx.Sender.Id = SenderId;
+            ctx.Recipient.Algorithm = ctx.Sender.Algorithm;
+            if (RecipientId == null) throw new ArgumentNullException("RecipientId");
+            ctx.Recipient.Id = RecipientId;
+            ctx.Recipient.ReplayWindow = new replayWindow(0, 64);
+
+            CBORObject info = CBORObject.NewArray();
+            info.Add(Cid);
+            info.Add(SenderId);
+            info.Add(ctx.Sender.Algorithm);
+            info.Add("Key");
+            info.Add(128);
+
+            IDigest sha256 = new Sha256Digest();
+            IDerivationFunction hkdf = new HkdfBytesGenerator(sha256);
+            hkdf.Init(new HkdfParameters(MasterSecret, null, info.EncodeToBytes()));
+
+            ctx.Sender.Key = new byte[128/8];
+            hkdf.GenerateBytes(ctx.Sender.Key, 0, ctx.Sender.Key.Length);
+
+            info[1] = CBORObject.FromObject(RecipientId);
+            hkdf.Init(new HkdfParameters(MasterSecret, null, info.EncodeToBytes()));
+            ctx.Recipient.Key = new byte[128/8];
+            hkdf.GenerateBytes(ctx.Recipient.Key, 0, ctx.Recipient.Key.Length);
+ 
+            info[3] = CBORObject.FromObject("IV");
+            info[4] = CBORObject.FromObject(56);
+            hkdf.Init(new HkdfParameters(MasterSecret, null, info.EncodeToBytes()));
+            ctx.Recipient.BaseIV = new byte[56/8];
+            hkdf.GenerateBytes(ctx.Recipient.BaseIV, 0, ctx.Recipient.BaseIV.Length);
+
+            info[1] = CBORObject.FromObject(SenderId);
+            hkdf.Init(new HkdfParameters(MasterSecret, null, info.EncodeToBytes()));
+            ctx.Sender.BaseIV = new byte[56/8];
+            hkdf.GenerateBytes(ctx.Sender.BaseIV, 0, ctx.Sender.BaseIV.Length);
+
+            return ctx;
+        }
+    }
+#endif
+}

--- a/CoAP.NET/OSCOAP/SecurityContext.cs
+++ b/CoAP.NET/OSCOAP/SecurityContext.cs
@@ -109,6 +109,10 @@ namespace CoAP.OSCOAP
             public void IncrementSequenceNumber() { _sequenceNumber += 1; }
         }
 
+        static int ContextNumber = 0;
+        int _contextNo;
+        public int ContextNo { get { return _contextNo; } }
+
         EntityContext _sender = new EntityContext();
         public EntityContext Sender { get { return _sender; } }
 
@@ -160,6 +164,9 @@ namespace CoAP.OSCOAP
             hkdf.Init(new HkdfParameters(MasterSecret, null, info.EncodeToBytes()));
             ctx.Sender.BaseIV = new byte[56/8];
             hkdf.GenerateBytes(ctx.Sender.BaseIV, 0, ctx.Sender.BaseIV.Length);
+
+            ctx._contextNo = SecurityContext.ContextNumber;
+            SecurityContext.ContextNumber += 1;
 
             return ctx;
         }

--- a/CoAP.NET/OSCOAP/SecurityContextSet.cs
+++ b/CoAP.NET/OSCOAP/SecurityContextSet.cs
@@ -17,10 +17,20 @@ namespace CoAP.OSCOAP
             _allContexts.Add(ctx);
         }
 
-        public SecurityContext FindByKid(byte[] kid)
+        public List<SecurityContext> FindByKid(byte[] kid)
         {
-            if (_allContexts.Count > 0) return _allContexts[0];
-            return null;
+            List<SecurityContext> contexts = new List<SecurityContext>();
+            foreach (SecurityContext ctx in _allContexts) {
+                if (kid.Length == ctx.Cid.Length) {
+                    bool match = true;
+                    for (int i=0; i<kid.Length;i++) if (kid[i] != ctx.Cid[i]) {
+                            match = false;
+                            break;
+                        }
+                    if (match) contexts.Add(ctx);
+                }
+            }
+            return contexts;
         }
     }
 }

--- a/CoAP.NET/OSCOAP/SecurityContextSet.cs
+++ b/CoAP.NET/OSCOAP/SecurityContextSet.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace CoAP.OSCOAP
+{
+    public class SecurityContextSet
+    {
+        List<SecurityContext> _allContexts = new List<SecurityContext>();
+        public static SecurityContextSet AllContexts = new SecurityContextSet();
+
+        public int Count { get { return _allContexts.Count; } }
+
+        public void Add(SecurityContext ctx)
+        {
+            _allContexts.Add(ctx);
+        }
+
+        public SecurityContext FindByKid(byte[] kid)
+        {
+            if (_allContexts.Count > 0) return _allContexts[0];
+            return null;
+        }
+    }
+}

--- a/CoAP.NET/Observe/ObserveRelation.cs
+++ b/CoAP.NET/Observe/ObserveRelation.cs
@@ -121,7 +121,7 @@ namespace CoAP.Observe
         public void Cancel()
         {
             if (log.IsDebugEnabled)
-                log.Debug("Cancel observe relation from " + _key + " with " + _resource.Path);
+                log.Debug("Cancel observe relation from " + _key + " with " + _resource.Uri);
             // stop ongoing retransmissions
             if (_exchange.Response != null)
                 _exchange.Response.Cancel();

--- a/CoAP.NET/Option.cs
+++ b/CoAP.NET/Option.cs
@@ -219,6 +219,10 @@ namespace CoAP
                 case OptionType.Block1:
                 case OptionType.Block2:
                     return new BlockOption(type);
+#if INCLUDE_OSCOAP                    
+                case OptionType.Oscoap:
+                    return new OSCOAP.OscoapOption();
+#endif
                 default:
                     return new Option(type);
             }

--- a/CoAP.NET/OptionType.cs
+++ b/CoAP.NET/OptionType.cs
@@ -142,7 +142,12 @@ namespace CoAP
         /// <remarks>draft-ietf-core-block</remarks>
         /// </summary>
         Size2 = 28,
-
+#if INCLUDE_OSCOAP
+        /// <summary>
+        /// <remarks>draft-ietf-core-oscoap</remarks>
+        /// </summary>
+        Oscoap = 999,
+#endif
         /// <summary>
         /// no-op for fenceposting
         /// <remarks>draft-bormann-coap-misc-04</remarks>

--- a/CoAP.NET/OptionType.cs
+++ b/CoAP.NET/OptionType.cs
@@ -146,7 +146,7 @@ namespace CoAP
         /// <summary>
         /// <remarks>draft-ietf-core-oscoap</remarks>
         /// </summary>
-        Oscoap = 999,
+        Oscoap = 65025,
 #endif
         /// <summary>
         /// no-op for fenceposting

--- a/CoAP.NET/Request.cs
+++ b/CoAP.NET/Request.cs
@@ -15,7 +15,9 @@ using System.Text.RegularExpressions;
 using CoAP.Log;
 using CoAP.Net;
 using CoAP.Observe;
+#if INCLUDE_OSCOAP
 using CoAP.OSCOAP;
+#endif
 
 namespace CoAP
 {

--- a/CoAP.NET/Request.cs
+++ b/CoAP.NET/Request.cs
@@ -15,6 +15,7 @@ using System.Text.RegularExpressions;
 using CoAP.Log;
 using CoAP.Net;
 using CoAP.Observe;
+using CoAP.OSCOAP;
 
 namespace CoAP
 {
@@ -32,6 +33,9 @@ namespace CoAP
         private Response _currentResponse;
         private IEndPoint _endPoint;
         private Object _sync;
+#if INCLUDE_OSCOAP
+        private SecurityContext _oscoapContext;
+#endif
 
         /// <summary>
         /// Fired when a response arrives.
@@ -386,5 +390,12 @@ namespace CoAP
         {
             return new Request(CoAP.Method.DELETE);
         }
+#if INCLUDE_OSCOAP
+        public SecurityContext OscoapContext
+        {
+            get { return _oscoapContext;}
+            set { _oscoapContext = value; }
+        }
+#endif
     }
 }

--- a/CoAP.NET/Server/Resources/CoapExchange.cs
+++ b/CoAP.NET/Server/Resources/CoapExchange.cs
@@ -173,7 +173,7 @@ namespace CoAP.Server.Resources
                 response.MaxAge = _maxAge;
             if (_eTag != null)
                 response.SetOption(Option.Create(OptionType.ETag, _eTag));
-
+ 
             _resource.CheckObserveRelation(_exchange, response);
 
             _exchange.SendResponse(response);

--- a/CoAP.NET/Stack/CoapStack.cs
+++ b/CoAP.NET/Stack/CoapStack.cs
@@ -26,6 +26,10 @@ namespace CoAP.Stack
         public CoapStack(ICoapConfig config)
         {
             this.AddLast("Observe", new ObserveLayer(config));
+#if INCLUDE_OSCOAP
+            this.AddLast("SecureBlockwise", new OSCOAP.SecureBlockwiseLayer(config));
+            this.AddLast("OSCOAP", new OSCOAP.OscoapLayer(config));
+#endif
             this.AddLast("Blockwise", new BlockwiseLayer(config));
             this.AddLast("Token", new TokenLayer(config));
             this.AddLast("Reliability", new ReliabilityLayer(config));

--- a/CoAP.NET/Util/Utils.cs
+++ b/CoAP.NET/Util/Utils.cs
@@ -215,6 +215,10 @@ namespace CoAP.Util
                 appendIfNotNullOrEmpty(sb, "Block2", msg.Block2.ToString());
             if (msg.Observe.HasValue)
                 appendIfNotNullOrEmpty(sb, "Observe", msg.Observe.ToString());
+#if INCLUDE_OSCOAP                
+            if (msg.Oscoap != null)
+                appendIfNotNullOrEmpty(sb, "OSCOAP", msg.Oscoap.ToString());
+#endif
             return sb.ToString();
         }
 

--- a/CoAP.NET/project.json
+++ b/CoAP.NET/project.json
@@ -1,15 +1,29 @@
 ﻿{
   "version": "1.0.0-*",
   "description": "CoAP.NET.DNX Class Library",
-  "authors": [ "Sergei Gnezdov" ],
-  "tags": [ "" ],
+  "authors": [
+    "Sergei Gnezdov"
+  ],
+  "tags": [
+    ""
+  ],
   "projectUrl": "",
   "licenseUrl": "",
   "frameworks": {
-    "dnx451": { "frameworkAssemblies": {"System.ServiceModel": ""} }
+    "net40": {
+      "frameworkAssemblies": {
+        "System.ServiceModel": ""
+      }
+    },
+    "dnx451": {
+      "frameworkAssemblies": {
+        "System.ServiceModel": ""
+      }
+    }
   },
   "dependencies": {
-    "Common.Logging": "3.3.0"
+    "Common.Logging": "3.0.0",
+    "PeterO.Cbor": "2.4.2"
   },
   "compileExclude": [
     "Channel/UDPChannel.NET20.cs",
@@ -18,5 +32,8 @@
     "Util/System.Collections.Concurrent",
     "Util/System.Collections.Generic",
     "Util/Delegates.cs"
-  ]
+  ],
+  "runtimes": {
+    "win": {}
+  }
 }


### PR DESCRIPTION
This is not really a request for doing a pull yet, it is more a case of asking for review to see if this is something that you are interested in and if you think that it is in the correct direction.

This is not a complete implementation yet.  Some of the things that I know are missing:
* Observe and blockwise transfer are going to require doing a cached exchange in the OSCOAP layer.
* The OSCOAP option number has not been assigned so I have chosen something arbitrary (and wrong) for testing purposes.
* Need to figure out all of the builds to make sure that all of them will build correctly.  Part of this is going to be the question of how do do builds for both with and without OSCOAP in all probability  given the set of components that I am dragging in for cryptography.  Also there may be a problem as not all of the modules that I am currently using are signed and thus if this is signed then they cannot be loaded.
