### PR TITLE
Allow broadcast requests to the servers

### DIFF
--- a/CoAP.NET/Channel/UDPChannel.cs
+++ b/CoAP.NET/Channel/UDPChannel.cs
@@ -294,13 +294,24 @@ namespace CoAP.Channel
         {
             UDPSocket socket = NewUDPSocket(addressFamily, bufferSize);
 
+            try
+            {
+                socket.Socket.EnableBroadcast = true;
+                socket.Socket.ExclusiveAddressUse = false;
+                socket.Socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            }
+            catch (Exception)
+            {
+                // ignore
+            }
+
             // do not throw SocketError.ConnectionReset by ignoring ICMP Port Unreachable
             const Int32 SIO_UDP_CONNRESET = -1744830452;
             try
             {
                 socket.Socket.IOControl(SIO_UDP_CONNRESET, new Byte[] { 0 }, null);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // ignore
             }


### PR DESCRIPTION
It allows the client to use requests of the form: "coap://255.255.255.255/.well-known/core" to search for primitive servers on the local area network (LAN) that do not support multicasts.

It also enables the client to reuse sockets, since the packets have a built-in mechanism for determining if the response matches the request.